### PR TITLE
upgraded to kotlin 1.3.40 and add test support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
 import java.util.*
 
 plugins {
-    id("kotlin2js") version "1.3.31"
-    id("kotlin-dce-js") version "1.3.31"
+    kotlin("js") version "1.3.40"
+    id("kotlin-dce-js") version "1.3.40"
     id("org.tenne.rest") version "0.4.2"
 }
 
@@ -30,7 +30,7 @@ val host = screepsHost ?: "https://screeps.com"
 fun String.encodeBase64() = Base64.getEncoder().encodeToString(this.toByteArray())
 
 tasks {
-    "compileKotlin2Js"(Kotlin2JsCompile::class) {
+    "compileKotlinJs"(Kotlin2JsCompile::class) {
         kotlinOptions {
             moduleKind = "commonjs"
             outputFile = "${buildDir}/screeps/main.js"
@@ -39,7 +39,7 @@ tasks {
         }
     }
 
-    "runDceKotlinJs"(KotlinJsDce::class) {
+    "runDceKotlin"(KotlinJsDce::class) {
         keep("main.loop")
         dceOptions.devMode = false
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,23 @@ repositories {
 }
 
 dependencies {
-    implementation("ch.delconte.screeps-kotlin:screeps-kotlin-types:1.3.0")
+    implementation("ch.delconte.screeps-kotlin:screeps-kotlin-types:1.5.0")
     implementation(kotlin("stdlib-js"))
     testImplementation(kotlin("test-js"))
 }
+kotlin {
+    target {
+        useCommonJs()
+        nodejs()
+    }
+
+    sourceSets["main"].dependencies {
+        implementation(kotlin("stdlib-js"))
+    }
+}
+
+
+val kotlinSourcesJar by tasks
 
 val screepsUser: String? by project
 val screepsPassword: String? by project
@@ -32,7 +45,6 @@ fun String.encodeBase64() = Base64.getEncoder().encodeToString(this.toByteArray(
 tasks {
     "compileKotlinJs"(Kotlin2JsCompile::class) {
         kotlinOptions {
-            moduleKind = "commonjs"
             outputFile = "${buildDir}/screeps/main.js"
             sourceMap = true
             metaInfo = true

--- a/src/test/kotlin/DummyTest.kt
+++ b/src/test/kotlin/DummyTest.kt
@@ -1,0 +1,9 @@
+import kotlin.test.Test
+
+internal class DummyTest {
+    @Test
+    fun dummyTest() {
+        // Put your testing code here
+        // Test report will be in /build/reports/test/test
+    }
+}


### PR DESCRIPTION
Gradle changed the plugin and the task names with 1.3.40
I think in a few days, they'll have updated the documentation as well, so we can build simple support for tests.

For further information see: https://blog.jetbrains.com/kotlin/2019/06/kotlin-1-3-40-released/
(Just found screeps types in the comments section ;)

 - [ ] Update Readme?
 - [ ] Upgrade the Gradle wrapper?