### PR TITLE
Added examples of how to setup persistent variables for other classes  

### DIFF
--- a/src/main/kotlin/starter/BasicCreepMemory.kt
+++ b/src/main/kotlin/starter/BasicCreepMemory.kt
@@ -1,9 +1,0 @@
-package starter
-
-import screeps.api.CreepMemory
-import screeps.utils.memory.memory
-
-
-var CreepMemory.building: Boolean by memory { false }
-var CreepMemory.pause: Int by memory { 0 }
-var CreepMemory.role by memory(Role.UNASSIGNED)

--- a/src/main/kotlin/starter/BasicMemory.kt
+++ b/src/main/kotlin/starter/BasicMemory.kt
@@ -1,0 +1,33 @@
+package starter
+
+import screeps.api.*
+import screeps.utils.memory.memory
+
+/* Add the variables that you want to store to the persistent memory for each object type.
+* They can be accessed by using the .memory attribute of any of the instances of that class
+* i.e. creep.memory.building = true */
+
+/* Creep.memory */
+var CreepMemory.building: Boolean by memory { false }
+var CreepMemory.pause: Int by memory { 0 }
+var CreepMemory.role by memory(Role.UNASSIGNED)
+
+
+/* Rest of the persistent memory structures.
+* These set an unused test variable to 0. This is done to illustrate the how to add variables to
+* the memory. Change or remove it at your convenience.*/
+
+/* Power creep is a late game hero unit that is spawned from a Power Spawn
+   see https://docs.screeps.com/power.html for more details.
+   This set sets up the memory for the PowerCreep.memory class.
+ */
+var PowerCreepMemory.test : Int by memory { 0 }
+
+/* flag.memory */
+var FlagMemory.test : Int by memory { 0 }
+
+/* room.memory */
+var RoomMemory.test : Int by memory { 0 }
+
+/* spawn.memory */
+var SpawnMemory.test : Int by memory { 0 }


### PR DESCRIPTION

When expanding on the starter package, I wanted to add variables to the persistent memory of the different object types in the game. It took me quite some time to figure out how to do this for objects other than creeps. 

Hoping to help out future users of this package, I added comments and examples to  BasicCreepMemory.kt on how to create a test variable for all of the classes that support persistent memory . Hopefully future users can use this as a quick reference. 

I also moved BasicCreepMemory.kt to BasicMemory.kt, since it was now setting up more than just creeps.

Could you please merge this into the main project so that others can benefit from it.
Thank you.

