### PR TITLE
Update README.md with screepsmod-auth link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ This can be very useful to store non-essential but expensive-to-calculate data, 
 
 ### Troubleshooting
 
+#### Important! To upload code to a private server, you must have [screepsmod-auth](https://github.com/ScreepsMods/screepsmod-auth) installed and configured!
+If you're using the 'private server' option in Steam, you can install `screepsmod-auth` from the Steam Workshop.
+
 #### Gradle says it deployed correctly, but my code doesnt show up.
 Make sure you deployed to a branch which exists on the Server, if not it will fail silently.
 


### PR DESCRIPTION
Added info/link for screepsmod-auth.

Similar to https://github.com/screepers/screeps-typescript-starter/blob/master/README.md